### PR TITLE
Fea: env config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.5-alpine
 WORKDIR /project
 COPY . /project
 COPY openstack_vim_driver/etc/configuration.ini /etc/openbaton/openstack_vim_driver.ini
-RUN ["apk", "update"]
-RUN ["apk", "add", "gcc", "musl-dev", "linux-headers", "libffi-dev", "openssl-dev"]
+RUN ["apk", "add", "--no-cache", "gcc", "musl-dev", "linux-headers", "libffi-dev", "openssl-dev"]
 RUN ["pip", "install", "-r", "requirements.txt"]
 RUN ["pip", "install", "."]
 ENTRYPOINT ["openstack-vim-driver"]

--- a/openstack_vim_driver/etc/configuration.ini
+++ b/openstack_vim_driver/etc/configuration.ini
@@ -9,7 +9,7 @@ wait-for-vm=15
 [rabbitmq]
 username=openbaton-manager-user
 password=openbaton
-broker_ip=127.0.0.1
+broker_ip=%(RABBITMQ)s
 port=5672
 heartbeat=1
 exchange-name=openbaton-exchange

--- a/openstack_vim_driver/etc/configuration.ini
+++ b/openstack_vim_driver/etc/configuration.ini
@@ -9,7 +9,7 @@ wait-for-vm=15
 [rabbitmq]
 username=openbaton-manager-user
 password=openbaton
-broker_ip=%(RABBITMQ)s
+broker_ip=%(RABBITMQ_IP)s
 port=5672
 heartbeat=1
 exchange-name=openbaton-exchange

--- a/openstack_vim_driver/openstack_vim_driver.py
+++ b/openstack_vim_driver/openstack_vim_driver.py
@@ -1004,7 +1004,7 @@ def main():
         except Exception as e:
             sys.stderr.write('Error in logging configuration. Using the default configuration: {}\n'.format(e))
             logging.basicConfig()
-        cp = configparser.ConfigParser()
+        cp = configparser.ConfigParser(os.environ)
         try:
             cp.read(config_file_location)
             conf_map = get_map('general', cp)


### PR DESCRIPTION
Minimal changes to be able to get the broker IP (and in the future also other configuration parameters) from the environment so we can integrate the driver as part of a docker-compose deployment.